### PR TITLE
Update package exports with explicit type definitions

### DIFF
--- a/.changeset/remove-custom-out-extensions.md
+++ b/.changeset/remove-custom-out-extensions.md
@@ -1,0 +1,5 @@
+---
+"comparator.ts": patch
+---
+
+Use tsdown's default output extensions (`.mjs`/`.cjs` and `.d.mts`/`.d.cts`) and update package exports with explicit `types` conditions per environment.

--- a/.changeset/remove-custom-out-extensions.md
+++ b/.changeset/remove-custom-out-extensions.md
@@ -1,5 +1,0 @@
----
-"comparator.ts": patch
----
-
-Use tsdown's default output extensions (`.mjs`/`.cjs` and `.d.mts`/`.d.cts`) and update package exports with explicit `types` conditions per environment.

--- a/package.json
+++ b/package.json
@@ -12,14 +12,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
     }
   },
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "main": "dist/index.cjs",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,10 +7,6 @@ export default defineConfig((options) => ({
   dts: true,
   minify: !options.watch,
   sourcemap: !options.watch,
-  outExtensions: ({ format }) =>
-    format === "es"
-      ? { js: ".js", dts: ".d.ts" }
-      : { js: ".cjs", dts: ".d.cts" },
   attw: { level: "error" },
   publint: true,
 }));


### PR DESCRIPTION
## Summary
Updated the package.json exports configuration to explicitly specify type definition files for both ES module and CommonJS builds, and removed the corresponding outExtensions configuration from tsdown.config.ts.

## Key Changes
- **package.json exports**: Restructured the exports field to use nested objects that explicitly map type definitions and default exports:
  - `import` export now points to `./dist/index.mjs` with types at `./dist/index.d.mts`
  - `require` export now points to `./dist/index.cjs` with types at `./dist/index.d.cts`
- **tsdown.config.ts**: Removed the `outExtensions` configuration that was dynamically setting file extensions based on format, as the explicit exports in package.json now handle this mapping

## Implementation Details
This change improves type resolution for consumers of the package by making type definitions discoverable through the package.json exports field, which is the modern standard for dual-package exports. The removal of `outExtensions` from the build config suggests the build tool now handles these extensions automatically or through other configuration.

https://claude.ai/code/session_018FCdWQwnDktK4TU9nkG93Z