### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simonkberg/comparator.ts/security/code-scanning/11](https://github.com/simonkberg/comparator.ts/security/code-scanning/11)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults.  
Best single fix here: set

- `contents: read`

at workflow root (after `on` and before `jobs`). This is the minimal recommended baseline and is sufficient for `actions/checkout` and typical CI read operations. It does not change existing workflow functionality.

No imports/methods/dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
