### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/simonkberg/comparator.ts/security/code-scanning/10](https://github.com/simonkberg/comparator.ts/security/code-scanning/10)

Add an explicit `permissions` block to `.github/workflows/release.yml` so token scopes are intentionally restricted.  
Best single fix without changing behavior is to set workflow-level permissions immediately after `on` (or after `concurrency`) and grant only what this release job needs:

- `contents: write` (needed to create/update release PRs, tags, releases, commits)
- `pull-requests: write` (needed by changesets to create/update release PRs)

This keeps functionality intact while avoiding broad default permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
