### PR TITLE
Drop Node.js 20.x from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
Remove Node.js 20.x from the CI test matrix, keeping only 22.x and 24.x versions.

## Changes
- Removed Node.js 20.x from the GitHub Actions CI workflow matrix
- CI will now test against Node.js 22.x and 24.x LTS versions only

## Details
This change aligns the CI pipeline with the project's supported Node.js versions, focusing testing efforts on more recent LTS releases.

https://claude.ai/code/session_016ryg8jqPZmrXtRe7ucGNpB