### PR TITLE
Update dependency pnpm to v11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.3"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a"
 }


### PR DESCRIPTION
## Summary

Bumps the `packageManager` field to `pnpm@11.1.1+sha512.d1fdf...`. Run via `corepack use pnpm@11.1.1` so the resolved entry carries the SHA-512 integrity hash that corepack expects.

Supersedes Renovate's #389, which has the plain version string without the integrity hash.

## Test plan

- [ ] CI matrix passes on 22.x / 24.x / 26.x with the new pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)