### PR TITLE
Add Claude Code automatic PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+            - Type safety and TypeScript correctness
+            - Test coverage for new/changed behavior
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` running `anthropics/claude-code-action@v1` on PR events
- Uses the progress-tracking variant (`track_progress: true`) with TypeScript/test-coverage focus added to the prompt
- Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` secret; action pinned by SHA to match existing CI style (Renovate will keep it current)

## Test plan
- [ ] Open a test PR and confirm Claude posts a tracking comment, then inline review feedback
- [ ] Verify the workflow has access to `CLAUDE_CODE_OAUTH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)