### PR TITLE
Skip Claude review on changeset-release branches

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   review:
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds a job-level `if:` to skip the Claude review workflow when `github.head_ref` starts with `changeset-release/` (e.g. #397)
- `pull_request` `branches:` filters the base branch, not the head, so this needs `if:` rather than the trigger-level filter

## Test plan
- [ ] Next Changesets release PR opens/updates without triggering a Claude review run
- [ ] Regular PRs continue to be reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)