### PR TITLE
Allow renovate bot PRs in Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
+          allowed_bots: renovate[bot],claude[bot]
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Add `allowed_bots: renovate[bot],claude[bot]` to the Claude Code Review action so it no longer fails on renovate-initiated PRs with `Workflow initiated by non-human actor: renovate (type: Bot)`.

## Test plan
- [ ] Renovate opens a PR and the Claude review workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)