### PR TITLE
Extend renovate config:best-practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
+    "config:best-practices",
     "config:js-lib",
-    "helpers:pinGitHubActionDigests",
-    ":configMigration",
     ":maintainLockFilesWeekly",
     ":automergeMinor",
     ":automergeDigest",


### PR DESCRIPTION
## Summary
- Adds `config:best-practices` to the renovate extends list
- Removes `helpers:pinGitHubActionDigests` and `:configMigration` since both are now included via `config:best-practices`

See: https://docs.renovatebot.com/presets-config/#configbest-practices

## Test plan
- [ ] Renovate dashboard reflects the new config on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)